### PR TITLE
org.webosports.service.location: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/org.webosports.service.location.api.json
+++ b/files/sysbus/org.webosports.service.location.api.json
@@ -1,5 +1,5 @@
 {
-    "services": [
+    "location-service.operation": [
         "org.webosports.location/getCurrentPosition",
         "org.webosports.location/startTracking",
         "org.webosports.location/getAutoLocate",

--- a/files/sysbus/org.webosports.service.location.perm.json
+++ b/files/sysbus/org.webosports.service.location.perm.json
@@ -1,20 +1,20 @@
 {
     "org.webosports.location": [ 
-        "networking.internal", "networking.query", "telephony"
+        "networkconnection.management", "networkconnection.query", "telephony.management", "telephony.query", "wifi.management", "wifi.query"
     ],
     "org.webosports.service.location": [ 
-        "networking.internal", "networking.query", "telephony"
+        "networkconnection.management", "networkconnection.query", "telephony.management", "telephony.query", "wifi.management", "wifi.query"
     ],
     "com.palm.location": [ 
-        "networking.internal", "networking.query", "telephony"
+        "networkconnection.management", "networkconnection.query", "telephony.management", "telephony.query", "wifi.management", "wifi.query"
     ],
     "com.palm.service.location": [ 
-        "networking.internal", "networking.query", "telephony"
+        "networkconnection.management", "networkconnection.query", "telephony.management", "telephony.query", "wifi.management", "wifi.query"
     ],
     "com.webos.location": [ 
-        "networking.internal", "networking.query", "telephony"
+        "networkconnection.management", "networkconnection.query", "telephony.management", "telephony.query", "wifi.management", "wifi.query"
     ],
     "com.webos.service.location": [ 
-        "networking.internal", "networking.query", "telephony"
+        "networkconnection.management", "networkconnection.query", "telephony.management", "telephony.query", "wifi.management", "wifi.query"
     ]
 }

--- a/files/sysbus/org.webosports.service.location.role.json.in
+++ b/files/sysbus/org.webosports.service.location.role.json.in
@@ -1,5 +1,6 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/location-service",
+    "trustLevel": "oem",
     "type": "privileged",
     "allowedNames": ["org.webosports.service.location","org.webosports.location","com.palm.location", "com.palm.service.location", "com.webos.location", "com.webos.service.location"],
     "permissions": [


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
